### PR TITLE
Allow to use any environments for Sentry

### DIFF
--- a/k8s-itlabs-operator/connectors/sentry_connector/exceptions.py
+++ b/k8s-itlabs-operator/connectors/sentry_connector/exceptions.py
@@ -8,7 +8,3 @@ class SentryConnectorCrdDoesNotExist(SentryConnectorError):
 
 class NonExistSecretForSentryConnector(SentryConnectorError):
     ...
-
-
-class EnvironmentValueError(ValueError):
-    ...

--- a/k8s-itlabs-operator/connectors/sentry_connector/factories/dto_factory.py
+++ b/k8s-itlabs-operator/connectors/sentry_connector/factories/dto_factory.py
@@ -2,7 +2,6 @@ from connectors.sentry_connector import specifications
 from connectors.sentry_connector.dto import SentryConnector, SentryMsSecretDto, \
     SentryConnectorMicroserviceDto, SentryApiSecretDto
 from connectors.sentry_connector.crd import SentryConnectorCrd
-from connectors.sentry_connector.exceptions import EnvironmentValueError
 
 
 class SentryMsSecretDtoFactory:
@@ -47,10 +46,7 @@ class SentryConnectorMicroserviceDtoFactory:
     @staticmethod
     def _parse_environment(env: str) -> str:
         """Возвращает сокращенное название среды окружения"""
-        try:
-            return specifications.SENTRY_AVAILABLE_ENVIRONMENTS[env].lower()
-        except KeyError:
-            raise EnvironmentValueError("Environment label contains invalid value")
+        return specifications.SENTRY_TRANSFORM_ENVIRONMENTS.get(env, env)
 
 
 class SentryApiSecretDtoFactory:

--- a/k8s-itlabs-operator/connectors/sentry_connector/specifications.py
+++ b/k8s-itlabs-operator/connectors/sentry_connector/specifications.py
@@ -28,8 +28,7 @@ SENTRY_VAR_NAMES = (
 )
 
 
-SENTRY_AVAILABLE_ENVIRONMENTS = {
+SENTRY_TRANSFORM_ENVIRONMENTS = {
     "development": "dev",
-    "stage": "stage",
     "production": "prod",
 }

--- a/k8s-itlabs-operator/connectors/sentry_connector/tests/factory_tests.py
+++ b/k8s-itlabs-operator/connectors/sentry_connector/tests/factory_tests.py
@@ -1,16 +1,30 @@
 import pytest
 
 from connectors.sentry_connector import specifications
-from connectors.sentry_connector.exceptions import EnvironmentValueError
 from connectors.sentry_connector.factories.dto_factory import SentryConnectorMicroserviceDtoFactory
 
 
 @pytest.mark.unit
 class TestSentryConnectorMicroserviceDtoFactory:
 
-    def test_label_contain_incorrect_environment_value(self):
-        annotations = {specifications.SENTRY_ENVIRONMENT_ANNOTATION: "dev"}
+    def test_annotation_contain_transform_environment_value(self):
         labels = {}
+        annotations = {
+            specifications.SENTRY_ENVIRONMENT_ANNOTATION: "development"
+        }
 
-        with pytest.raises(EnvironmentValueError):
-            SentryConnectorMicroserviceDtoFactory.dto_from_annotations(annotations, labels)
+        dto = SentryConnectorMicroserviceDtoFactory.dto_from_annotations(
+            annotations, labels
+        )
+
+        assert dto.environment == "dev"
+
+    def test_annotation_contain_unchangeable_environment_value(self):
+        labels = {}
+        annotations = {specifications.SENTRY_ENVIRONMENT_ANNOTATION: "any"}
+
+        dto = SentryConnectorMicroserviceDtoFactory.dto_from_annotations(
+            annotations, labels
+        )
+
+        assert dto.environment == "any"

--- a/k8s-itlabs-operator/operators/sentry.py
+++ b/k8s-itlabs-operator/operators/sentry.py
@@ -8,7 +8,7 @@ from operators.dto import ConnectorStatus, MutationHookStatus
 from connectors.sentry_connector.services.sentry_connector import SentryConnectorService
 from connectors.sentry_connector.factories.dto_factory import SentryConnectorMicroserviceDtoFactory
 from connectors.sentry_connector.factories.service_factories.sentry_connector import SentryConnectorServiceFactory
-from connectors.sentry_connector.exceptions import SentryConnectorError, EnvironmentValueError
+from connectors.sentry_connector.exceptions import SentryConnectorError
 from utils.common import OwnerReferenceDto, get_owner_reference
 
 
@@ -26,12 +26,7 @@ def create_pods(body, patch, spec, labels, annotations, **_):
     if not status.is_used:
         logging.info(f"[{owner_fmt}] Sentry connector is not used, because no expected annotations")
         return status
-    try:
-        ms_sentry_conn = SentryConnectorMicroserviceDtoFactory.dto_from_annotations(annotations, labels)
-    except EnvironmentValueError as e:
-        logging.error(f"[{owner_fmt}] Problem with Sentry connector", exc_info=e)
-        status.exception = e
-        return status
+    ms_sentry_conn = SentryConnectorMicroserviceDtoFactory.dto_from_annotations(annotations, labels)
 
     sentry_conn_service = SentryConnectorServiceFactory.create_sentry_connector_service()
     logging.info(f"[{owner_fmt}] Sentry connector service is created")

--- a/k8s-itlabs-operator/operators/tests/sentry_tests.py
+++ b/k8s-itlabs-operator/operators/tests/sentry_tests.py
@@ -191,7 +191,7 @@ def test_sentry_operator_on_initial_deployment_application(k8s, vault, sentry, a
     keys = sentry.get_sentry_project_keys(app_name)
     assert len(keys) > 0
     assert any(
-        k.name == specifications.SENTRY_AVAILABLE_ENVIRONMENTS[APP_DEPLOYMENT_ENVIRONMENT]
+        k.name == specifications.SENTRY_TRANSFORM_ENVIRONMENTS[APP_DEPLOYMENT_ENVIRONMENT]
         and k.dsn == secret[specifications.SENTRY_DSN_KEY]
         for k in keys
     )


### PR DESCRIPTION
Transform only `development` to `dev` and `production` to `prod` for compatibility.